### PR TITLE
add func to update max copy

### DIFF
--- a/src/OptimismL1Proxy.sol
+++ b/src/OptimismL1Proxy.sol
@@ -21,7 +21,7 @@ contract OptimismL1Proxy is IOptimismL1ProxyEvents {
   using ExcessivelySafeCall for address;
 
   // Maximum bytes to copy from the function call return.
-  uint16 constant MAX_COPY = 150;
+  uint16 public maxCopy = 150;
 
   // Error indicating that the caller of the function is unauthorized.
   error UnauthorizedCaller();
@@ -57,7 +57,7 @@ contract OptimismL1Proxy is IOptimismL1ProxyEvents {
   function executeFunction(address dst_, uint256 msgValue_, bytes calldata payload_) external onlyAuthenticatedCall {
     // The caller of the function is trusted but we still use excessivelySafeCall to ensure no
     // malicious reverts can happen.
-    (bool success, bytes memory ret) = dst_.excessivelySafeCall(gasleft(), msgValue_, MAX_COPY, payload_);
+    (bool success, bytes memory ret) = dst_.excessivelySafeCall(gasleft(), msgValue_, maxCopy, payload_);
 
     if (success) emit FunctionCallSuccess(dst_, ret, payload_);
     else emit FunctionCallFailed(dst_, ret, payload_);
@@ -69,10 +69,15 @@ contract OptimismL1Proxy is IOptimismL1ProxyEvents {
   /// @param value_ The amount of ETH to transfer. Note that the proxy must have ETH GTE to this value or the
   /// transaction will revert.
   function executeTransferEth(address dst_, uint256 value_) external onlyAuthenticatedCall {
-    (bool success,) = dst_.excessivelySafeCall(gasleft(), value_, MAX_COPY, "");
+    (bool success,) = dst_.excessivelySafeCall(gasleft(), value_, maxCopy, "");
 
     if (success) emit TransferSuccess(dst_, value_);
     else emit TransferFailed(dst_, value_, address(this).balance);
+  }
+
+  function updateMaxCopy(uint16 newMaxCopy_) external onlyAuthenticatedCall {
+    emit MaxCopyUpdated(maxCopy, newMaxCopy_);
+    maxCopy = newMaxCopy_;
   }
 
   /* ---- Access Control ---- */

--- a/src/interfaces/IOptimismL1ProxyEvents.sol
+++ b/src/interfaces/IOptimismL1ProxyEvents.sol
@@ -12,6 +12,8 @@ interface IOptimismL1ProxyEvents {
   event FunctionCallSuccess(address indexed to, bytes result, bytes payload);
   // Event indicating that the function call failed.
   event FunctionCallFailed(address indexed to, bytes reason, bytes payload);
+  // Event indicating that the maxCopy has been updated.
+  event MaxCopyUpdated(uint16 previousMaxCopy, uint16 newMaxCopy);
   // Event indicating native currency has been transfered.
   event TransferSuccess(address indexed to, uint256 amount);
   // Event indicating native currency transfer has failed.

--- a/test/OptimismL1Proxy.t.sol
+++ b/test/OptimismL1Proxy.t.sol
@@ -306,4 +306,19 @@ contract OptimismL1ProxyTest is Test, ITestEvents, IOptimismL1ProxyEvents {
     vm.deal(address(this), 1e18);
     address(proxy).call{value: 1e18}("");
   }
+
+  function test_updateMaxCopy() public {
+    uint16 newMaxCopy_ = 200;
+    OptimismL1Proxy proxy_ = new OptimismL1Proxy(address(this), messenger);
+
+    // Start ownership transfer.
+    messenger.setSender(address(this));
+    vm.expectEmit();
+    emit MaxCopyUpdated(proxy_.maxCopy(), newMaxCopy_);
+    messenger.sendMessage(
+      address(proxy_), abi.encodeWithSelector(OptimismL1Proxy.updateMaxCopy.selector, newMaxCopy_), 0
+    );
+
+    assertEq(proxy_.maxCopy(), newMaxCopy_);
+  }
 }


### PR DESCRIPTION
there may be a case when maxCopy needs to be greater than 150 bytes

> As an example, a user might want to execute a function that returns a struct of 5 uint256 values. This struct will be $32*5=160$ bytes long, so it will not be fully copied by the call to excessivelySafeCall() . The FunctionCallSuccess event for this transaction will not include all of the desired data and there is no way for the user to get the full return value by calling executeFunction().